### PR TITLE
Install wxWidgets for build pipeline

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -17,9 +17,13 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+
+    - name: Install dependencies
+      run: sudo apt install libwxgtk3.2-dev
+
     - uses: actions/checkout@v4
 
     - name: Configure CMake


### PR DESCRIPTION
## Summary by Sourcery

Install wxWidgets headers in the CI workflow to support the build process on Ubuntu.

CI:
- Add installation step for wxWidgets headers in the CI workflow to ensure necessary dependencies are available for the build process.